### PR TITLE
Add packaging options in build.gradle.kts to exclude duplicate META-I…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,22 @@ android {
             )
         }
     }
+    
+    // Add packaging options to handle duplicate files
+    packaging {
+        resources {
+            excludes += listOf(
+                "META-INF/NOTICE.md",
+                "META-INF/LICENSE.md",
+                "META-INF/DEPENDENCIES",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/NOTICE",
+                "META-INF/NOTICE.txt"
+            )
+        }
+    }
+    
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
…NF files, improving build process and reducing potential conflicts.